### PR TITLE
 Made code compatible with Visual Studio 2015:

### DIFF
--- a/ctti/detail/pretty_function.hpp
+++ b/ctti/detail/pretty_function.hpp
@@ -14,11 +14,11 @@
     #define CTTI_PRETTY_FUNCTION_PREFIX "ctti::type_id_t ctti::detail::type_id() [T = "
     #define CTTI_PRETTY_FUNCTION_SUFFIX "]"
 #elif defined(_MSC_VER)
-	#define CTTI_PRETTY_FUNCTION __FUNCSIG__
-	#define CTTI_PRETTY_FUNCTION_PREFIX "struct ctti::type_id_t __cdecl ctti::detail::type_id<"
-	#define CTTI_PRETTY_FUNCTION_SUFFIX ">(void)"
+    #define CTTI_PRETTY_FUNCTION __FUNCSIG__
+    #define CTTI_PRETTY_FUNCTION_PREFIX "struct ctti::type_id_t __cdecl ctti::detail::type_id<"
+    #define CTTI_PRETTY_FUNCTION_SUFFIX ">(void)"
 #else
-	#error "No support for this compiler."
+    #error "No support for this compiler."
 #endif
 
 #define CTTI_PRETTY_FUNCTION_LEFT (sizeof(CTTI_PRETTY_FUNCTION_PREFIX) - 1)

--- a/ctti/detail/pretty_function.hpp
+++ b/ctti/detail/pretty_function.hpp
@@ -13,10 +13,15 @@
     #define CTTI_PRETTY_FUNCTION __PRETTY_FUNCTION__
     #define CTTI_PRETTY_FUNCTION_PREFIX "ctti::type_id_t ctti::detail::type_id() [T = "
     #define CTTI_PRETTY_FUNCTION_SUFFIX "]"
+#elif defined(_MSC_VER)
+	#define CTTI_PRETTY_FUNCTION __FUNCSIG__
+	#define CTTI_PRETTY_FUNCTION_PREFIX "struct ctti::type_id_t __cdecl ctti::detail::type_id<"
+	#define CTTI_PRETTY_FUNCTION_SUFFIX ">(void)"
+#else
+	#error "No support for this compiler."
 #endif
 
-#define CTTI_PRETTY_FUNCTION_BEGIN (sizeof(CTTI_PRETTY_FUNCTION_PREFIX) - 1)
-#define CTTI_PRETTY_FUNCTION_END (sizeof(CTTI_PRETTY_FUNCTION) - 1 - sizeof(CTTI_PRETTY_FUNCTION_SUFFIX) - 1)
-#define CTTI_PRETTY_FUNCTION_LENGTH (CTTI_PRETTY_FUNCTION_END - CTTI_PRETTY_FUNCTION_BEGIN)
+#define CTTI_PRETTY_FUNCTION_LEFT (sizeof(CTTI_PRETTY_FUNCTION_PREFIX) - 1)
+#define CTTI_PRETTY_FUNCTION_RIGHT (sizeof(CTTI_PRETTY_FUNCTION_SUFFIX) - 1)
 
 #endif //CTTI_PRETTY_FUNCTION_HPP

--- a/ctti/detail/string.hpp
+++ b/ctti/detail/string.hpp
@@ -17,9 +17,9 @@ namespace ctti
         {
             template<std::size_t N>
             constexpr string(const char (&str)[N]) :
-				str_{str},
-				length_{N},
-				hash_{sid_hash(length_, str)}
+                str_{str},
+                length_{N},
+                hash_{sid_hash(length_, str)}
             {}
 
             constexpr string(const char* str, std::size_t length) :
@@ -33,7 +33,7 @@ namespace ctti
                 return hash_;
             }
 
-			// note: not necessarily null-terminated!
+            // note: not necessarily null-terminated!
             constexpr const char* c_str() const
             {
                 return str_;
@@ -49,29 +49,29 @@ namespace ctti
                 return str_[i];
             }
 
-			template <std::size_t Left>
+            template <std::size_t Left>
             constexpr string trim_left() const
             {
-				return string{str_ + Left, length_ - Left};
+                return string{str_ + Left, length_ - Left};
             }
 
-			template <std::size_t Right>
-			constexpr string trim_right() const
-			{
-				return string{str_, length_ - Right - 1};
-			}
+            template <std::size_t Right>
+            constexpr string trim_right() const
+            {
+                return string{str_, length_ - Right - 1};
+            }
 
-			template <std::size_t Left, std::size_t Right>
-			constexpr string trim() const
-			{
-				return trim_left<Left>().trim_right<Right>();
-			}
+            template <std::size_t Left, std::size_t Right>
+            constexpr string trim() const
+            {
+                return trim_left<Left>().trim_right<Right>();
+            }
 
             friend std::ostream& operator<<(std::ostream& os, const string& str)
             {
-				for (std::size_t i = 0u; i != str.length_; ++i)
-					os << str[i];
-				return os;
+                for (std::size_t i = 0u; i != str.length_; ++i)
+                    os << str[i];
+                return os;
             }
 
         private:

--- a/ctti/detail/string.hpp
+++ b/ctti/detail/string.hpp
@@ -7,6 +7,8 @@
 
 #include <ostream>
 
+#include "hash.hpp"
+
 namespace ctti
 {
     namespace detail
@@ -15,7 +17,9 @@ namespace ctti
         {
             template<std::size_t N>
             constexpr string(const char (&str)[N]) :
-                string{str, N}
+				str_{str},
+				length_{N},
+				hash_{sid_hash(length_, str)}
             {}
 
             constexpr string(const char* str, std::size_t length) :
@@ -29,6 +33,7 @@ namespace ctti
                 return hash_;
             }
 
+			// note: not necessarily null-terminated!
             constexpr const char* c_str() const
             {
                 return str_;
@@ -44,25 +49,32 @@ namespace ctti
                 return str_[i];
             }
 
-            template<std::size_t Begin, std::size_t End>
-            constexpr string substr() const
+			template <std::size_t Left>
+            constexpr string trim_left() const
             {
-                return substr_<Begin>(std::make_index_sequence<End - Begin>{});
+				return string{str_ + Left, length_ - Left};
             }
+
+			template <std::size_t Right>
+			constexpr string trim_right() const
+			{
+				return string{str_, length_ - Right - 1};
+			}
+
+			template <std::size_t Left, std::size_t Right>
+			constexpr string trim() const
+			{
+				return trim_left<Left>().trim_right<Right>();
+			}
 
             friend std::ostream& operator<<(std::ostream& os, const string& str)
             {
-                return os << str.c_str();
+				for (std::size_t i = 0u; i != str.length_; ++i)
+					os << str[i];
+				return os;
             }
 
         private:
-            template<std::size_t Begin, std::size_t... Is>
-            constexpr string substr_(std::index_sequence<Is...>) const
-            {
-                const char str[] = {str_[Begin + Is]...};
-                return { str };
-            }
-
             const char* str_;
             std::size_t length_;
             hash_t hash_;

--- a/ctti/type_id.hpp
+++ b/ctti/type_id.hpp
@@ -23,7 +23,7 @@ namespace ctti
             return name_.hash();
         }
 
-		// note: name().c_str() isn't null-terminated properly!
+        // note: name().c_str() isn't null-terminated properly!
         constexpr detail::string name() const
         {
             return name_;
@@ -50,9 +50,9 @@ namespace ctti
         template<typename T>
         constexpr ctti::type_id_t type_id()
         {
-			// one-liner required by MSVC :(
-			return detail::make_string(CTTI_PRETTY_FUNCTION).
-					template trim<CTTI_PRETTY_FUNCTION_LEFT, CTTI_PRETTY_FUNCTION_RIGHT>();
+            // one-liner required by MSVC :(
+            return detail::make_string(CTTI_PRETTY_FUNCTION).
+                    template trim<CTTI_PRETTY_FUNCTION_LEFT, CTTI_PRETTY_FUNCTION_RIGHT>();
         }
     }
 
@@ -86,7 +86,7 @@ namespace std
     {
         constexpr std::size_t operator()(const ctti::type_id_t& id) const
         {
-			// quiet warning about possible loss of data
+            // quiet warning about possible loss of data
             return std::size_t(id.hash());
         }
     };

--- a/ctti/type_id.hpp
+++ b/ctti/type_id.hpp
@@ -23,6 +23,7 @@ namespace ctti
             return name_.hash();
         }
 
+		// note: name().c_str() isn't null-terminated properly!
         constexpr detail::string name() const
         {
             return name_;
@@ -49,10 +50,9 @@ namespace ctti
         template<typename T>
         constexpr ctti::type_id_t type_id()
         {
-            const auto str = detail::make_string(CTTI_PRETTY_FUNCTION);
-            const auto name = str.template substr<CTTI_PRETTY_FUNCTION_BEGIN, CTTI_PRETTY_FUNCTION_END>();
-
-            return {name};
+			// one-liner required by MSVC :(
+			return detail::make_string(CTTI_PRETTY_FUNCTION).
+					template trim<CTTI_PRETTY_FUNCTION_LEFT, CTTI_PRETTY_FUNCTION_RIGHT>();
         }
     }
 
@@ -86,7 +86,8 @@ namespace std
     {
         constexpr std::size_t operator()(const ctti::type_id_t& id) const
         {
-            return id.hash();
+			// quiet warning about possible loss of data
+            return std::size_t(id.hash());
         }
     };
 }


### PR DESCRIPTION
* changed CTTI_PRETTY_FUNCTION_BEGIN/END to _LEFT, _RIGHT specifying how much to trim (old code didn't work due to a different macro evaluation (?))
* removed string::substr(), added trim_* functions
* string::c_str() isn't null-terminated properly anymore!

Todo: Ugly warning C4307 due to overflow in sid_hash(), don't know how to get rid of it.

Your bug was indeed caused by substr(), it returned a pointer to a local array. ;)
It is fixed now at the cost that c_str() isn't properly null-terminated.