### PR TITLE
Fix for vs2015. In macro CTTI_TYPE_PRETTY_FUNCTION_PREFIX was "struct…

### DIFF
--- a/include/ctti/detail/pretty_function.hpp
+++ b/include/ctti/detail/pretty_function.hpp
@@ -46,7 +46,7 @@ constexpr ctti::detail::cstring value()
     #define CTTI_TYPE_PRETTY_FUNCTION_PREFIX "constexpr ctti::detail::cstring ctti::pretty_function::type() [with T = "
     #define CTTI_TYPE_PRETTY_FUNCTION_SUFFIX "]"
 #elif defined(_MSC_VER)
-    #define CTTI_TYPE_PRETTY_FUNCTION_PREFIX "struct ctti::detail::cstring __cdecl ctti::pretty_function::type<"
+    #define CTTI_TYPE_PRETTY_FUNCTION_PREFIX "class ctti::detail::cstring __cdecl ctti::pretty_function::type<"
     #define CTTI_TYPE_PRETTY_FUNCTION_SUFFIX ">(void)"
 #else
     #error "No support for this compiler."

--- a/include/ctti/detail/pretty_function.hpp
+++ b/include/ctti/detail/pretty_function.hpp
@@ -64,8 +64,8 @@ constexpr ctti::detail::cstring value()
     #define CTTI_VALUE_PRETTY_FUNCTION_SEPARATOR "; T Value = "
     #define CTTI_VALUE_PRETTY_FUNCTION_SUFFIX "]"
 #elif defined(_MSC_VER)
-    #define CTTI_VALUE_PRETTY_FUNCTION_PREFIX "struct ctti::detail::cstring __cdecl ctti::pretty_function::value<"
-    #define CTTI_VALUE_PRETTY_FUNCTION_SEPARATOR "; T Value = "
+    #define CTTI_VALUE_PRETTY_FUNCTION_PREFIX "class ctti::detail::cstring __cdecl ctti::pretty_function::value<"
+    #define CTTI_VALUE_PRETTY_FUNCTION_SEPARATOR ","
     #define CTTI_VALUE_PRETTY_FUNCTION_SUFFIX ">(void)"
 #else
     #error "No support for this compiler."


### PR DESCRIPTION
Fix for vs2015. In macro CTTI_TYPE_PRETTY_FUNCTION_PREFIX was "struct" instead of "class", so ctti::nameof<my_class_type>() returned "lass my_class_type" instead of "class my_class_type".