### PR TITLE
Explicit type castig for size_t(-1)

### DIFF
--- a/include/ctti/detail/name_filters.hpp
+++ b/include/ctti/detail/name_filters.hpp
@@ -60,7 +60,7 @@ constexpr const char* find_ith(const ctti::detail::cstring& name, const ctti::de
 
 constexpr const char* find_last(const ctti::detail::cstring& name, const ctti::detail::cstring& substring)
 {
-    return find_ith_impl(name, substring, name.end(), -1, true);
+    return find_ith_impl(name, substring, name.end(), static_cast<size_t>(-1), true);
 }
 
 constexpr const char* find(const ctti::detail::cstring& name, const ctti::detail::cstring& substring)


### PR DESCRIPTION
For to use all warnings are errors, explicit casting is needed for -1 to size_t